### PR TITLE
Fix full width header on search results

### DIFF
--- a/app/views/sprint-17/search/case-search-results.html
+++ b/app/views/sprint-17/search/case-search-results.html
@@ -2,8 +2,10 @@
 {% block pageTitle %}
   Cases
 {% endblock %}
-{% block beforeContent %}
+{% block header %}
   {% include "../includes/head-main.html" %}
+{% endblock %}
+{% block beforeContent %}
 {% endblock %}
 {% block content %}
   <div class="govuk-error-summary" data-module="govuk-error-summary">


### PR DESCRIPTION
Move from body before into header tag so that it displays full width.